### PR TITLE
Rename tsc to steering committee

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,4 +1,4 @@
-# Technical Steering Committee (TSC) Charter
+# Steering Committee Charter
 
 ## Goals of the project
 
@@ -25,7 +25,7 @@
  
 We have chosen to adapt our principles from [the Gov UK, Government Design Principles](https://www.gov.uk/guidance/government-design-principles) and the [Australian Digital Service Standard](https://www.dta.gov.au/help-and-advice/digital-service-standard/digital-service-standard-criteria), these guidelines have been iterated on since 2012 and provide a solid foundation for delivering government service.
 
-## Responsibilities of TSC
+## Responsibilities of Steering Committee
 
 - Technical development
 - Design curation
@@ -36,28 +36,28 @@ We have chosen to adapt our principles from [the Gov UK, Government Design Princ
 - GitHub repository hosting and npm publishing
 - [Code of Conduct](CODE-OF-CONDUCT.md) enforcement
 - Development process and any coding standards
-- Mediating technical conflicts between Collaborators and TSC projects
+- Mediating technical conflicts between Collaborators and Steering Committee projects
 - Changes to this Charter
-- Maintain a list of all TSC members in the README.md
+- Maintain a list of all Steering Committee members in the README.md
 - Curation of RFCs
 
-## Make up of TSC
+## Make up of Steering Committee
 
-The make up of TSC should be a diverse and multidisciplinary group:
+The make up of Steering Committee should be a diverse and multidisciplinary group:
 
 - Include a diverse multidisciplinary team (developers, designers, accessibility experts, others)
 - Include people from government entities
 - Include experts from the private sector as volunteer advisors
 
-## Becoming a member of TSC
+## Becoming a member of Steering Committee
 
-Interest to join TSC to become a Maintainer, should be forwarded to maintainers@designsystemau.org. Please include information about your experience with the system and why you would like to join this group.
+Interest to join Steering Committee to become a Maintainer, should be forwarded to maintainers@designsystemau.org. Please include information about your experience with the system and why you would like to join this group.
 
 Anyone, with any level of experience can become a Maintainer.
 
-Inactivity in TSC may result in Maintainer status being revoked.
+Inactivity in Steering Committee may result in Maintainer status being revoked.
 
-## Losing membership of TSC
+## Losing membership of Steering Committee
 
 Reasons one might lose their membership in this group:
 
@@ -65,11 +65,11 @@ Reasons one might lose their membership in this group:
 - Extended absence from the project, including not attending meetings
 - Ineffectiveness in the role
 
-## TSC meetings
+## Steering Committee meetings
 
-The TSC can be called to meet to discuss matters around:
+The Steering Committee can be called to meet to discuss matters around:
 
-- TSC membership issues
+- Steering Committee membership issues
 - Changes to this Charter
 - New initiatives or working groups
 - Planning for major milestones

--- a/HOW-WE-DO-PRS.md
+++ b/HOW-WE-DO-PRS.md
@@ -37,7 +37,7 @@ Before requesting a PR review, make sure you’ve ticked off the following.
 When a PR is ready for review, you must request a reviewer. You can either:
 
 - Select individual reviewers if you would like a review from specific people.
-- Select `designsystemau/maintainers` group if you would like a review from anyone in the TSC team
+- Select `designsystemau/maintainers` group if you would like a review from anyone in the Steering Committee
 
 <p align="center">
 	<img width="600" src="images/PR-maintainers.png" alt="Select the maintainers group from the request PR review dropdown">
@@ -48,7 +48,7 @@ If you request a review from two people, you only need to get approval from one 
 
 Reviewers will receive a notification in GitHub when a review has been requested either individually or as a member of the team.
 
-It is the responsibility of all TSC members to have visibility over their notifications so that developers do not have to chase up reviews.
+It is the responsibility of all Steering Committee members to have visibility over their notifications so that developers do not have to chase up reviews.
 
 ## Revoking a request
 
@@ -60,7 +60,7 @@ If you as the developer decide that the PR needs more work and is no longer in a
 
 ## Response Times
 
-If you are waiting on a TSC team review (e.g. not a specific person), you can shout out in the slack channel after a couple of days if you haven’t received any feedback.
+If you are waiting on a Steering Committee team review (e.g. not a specific person), you can shout out in the slack channel after a couple of days if you haven’t received any feedback.
 
 ## Merging PRs
 

--- a/PARTNERSHIP.md
+++ b/PARTNERSHIP.md
@@ -6,5 +6,5 @@ Please see the [list of Partners](partners/).
 
 ## How to become a partner
 
-Submit a [PR](https://github.com/designsystemau/TSC/compare) to this repository with a filled-out Partners agreement following our [Partners template](partners/README.md).
+Submit a [PR](https://github.com/designsystemau/steering-committee/compare) to this repository with a filled-out Partners agreement following our [Partners template](partners/README.md).
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Technical Steering Committee (TSC)
+# Steering Committee 
 
-Technical Steering Committee for Australian Government Design System.
+Steering Committee for the community-driven Australian Government Design System.
 
 To understand your role within this project, read [Roles](ROLES.md).
 
 To understand our expectations of conduct, read the [Code of Conduct](CODE-OF-CONDUCT.md).
 
-To understand how TSC works, read the [Charter of the TSC](CHARTER.md).
+To understand how Steering Committee works, read the [Charter](CHARTER.md).
 
-To participate in Design System Au Committee, please send an email to maintainers@designsystemau.org.
+To participate, please contact maintainers@designsystemau.org.
 
-The [Maintainers Github Team](https://github.com/orgs/designsystemau/teams/maintainers) can approve [RFCs](https://github.com/designsystemau/RFCs). 
+[Maintainers](https://github.com/orgs/designsystemau/teams/maintainers) can approve [RFCs](https://github.com/designsystemau/RFCs). 

--- a/ROLES.md
+++ b/ROLES.md
@@ -2,35 +2,35 @@
 
 > This document communicates the expected engagement from any person or organisation who engages with or uses the new, community supported Australian Government Design System
 
-Matt Sawkill from Code for Australia (@sawks on Slack and Github) is the primary contact for any questions relating to the mapping of roles and responsibilities.
+Matt Sawkill from Code for Australia (@sawks on Slack and GitHub) is the primary contact for any questions relating to the mapping of roles and responsibilities.
 
 <figure>
-    <img src="https://github.com/designsystemau/TSC/blob/main/images/roles-diagram.png" alt="The Australian Government Design System “support ecosystem”" style="width:100%">
+    <img src="https://github.com/designsystemau/steering-committee/blob/main/images/roles-diagram.png" alt="The Australian Government Design System “support ecosystem”" style="width:100%">
     <figcaption align = "center">The Australian Government Design System “support ecosystem”</figcaption>
 </figure>
 
 ## Maintainers (Technical Steering Committee)
 
-> A Maintainer is as a member of the Technical Steering Committee. The group of Maintainers forms the TSC.
+> A Maintainer is as a member of the Technical Steering Committee. The group of Maintainers forms the Steering Committee.
 
 * Maintainers are the core community members responsible for ongoing management and decision-making for the Design System
 * Anyone can become a Maintainer
-* The group of Maintainers forms the Technical Steering Committee (TSC)
-* Membership, responsibilities expectations of the TSC is covered by this [TSC Charter](CHARTER.md) and our [Code of Conduct](CODE-OF-CONDUCT.md)
-* In TSC, Maintainers have equal voting rights, and there is no other hierarchy within this group
+* The group of Maintainers forms the Technical Steering Committee (Steering Committee)
+* Membership, responsibilities expectations of the Steering Committee is covered by this [Steering Committee Charter](CHARTER.md) and our [Code of Conduct](CODE-OF-CONDUCT.md)
+* In Steering Committee, Maintainers have equal voting rights, and there is no other hierarchy within this group
 * Effectively they are the product managers and core developers of the Design System, leading the RFC process and facilitating working groups in order to make consensus decisions over technical architecture and future direction
-* The TSC are responsible managing contributions to the Design System made by supporting organisations, Government agencies and individuals in the broader community
+* The Steering Committee are responsible managing contributions to the Design System made by supporting organisations, Government agencies and individuals in the broader community
 * Maintainers will be attributed [location TBD]
 
 ## Supporting Organisations
 
 > Supporting Organisations describes any non-government entity.
 
-* Supporting Organisations are third parties who play an active and ongoing role in supporting the work of the TSC and the Design System itself
+* Supporting Organisations are third parties who play an active and ongoing role in supporting the work of the Steering Committee and the Design System itself
 * These organisations may include non-for-profits and NGOs, commercial vendors and Government organisations (operating in a different context to use of the Design System in delivery which is covered below) with a vested interest in the sustainability of the Design System
 * Support could take multiple forms, including but not limited to:
-    * Resourcing - their employees provide hands-on technical or non-technical assistance to the TSC
-    * Advice - their employees provide guidance to the TSC on specific issues
+    * Resourcing - their employees provide hands-on technical or non-technical assistance to the Steering Committee
+    * Advice - their employees provide guidance to the Steering Committee on specific issues
     * Promotion - helping drive awareness of the Design System and performing community outreach
     * Financial - sponsorship or direct funding to cover costs incurred in managing and supporting the Design System, running community events
 * Their engagement with the Design System will be formally defined by a [Partnership Agreement](PARTNERSHIP.md) and will be published in the open
@@ -42,8 +42,8 @@ Matt Sawkill from Code for Australia (@sawks on Slack and Github) is the primary
 
 * The primary way Government organisations will engage with the Design System is through using it in the delivery of their digital products and services
 * Government organisations have expectations of the Design System (suitability for its purpose, ongoing development, clarity on future features) that must be met by the community for them to be comfortable using it
-* The TSC expect Government organisations to act in the best interest of the Design System, which includes following the [MIT License](LICENSE), using our provided solutions for reporting issues and requesting changes, and sharing their work and findings with the community
-* Beyond their own delivery work, Government organisations may also act in support of the Design System & TSC, as defined above.
+* The Steering Committee expect Government organisations to act in the best interest of the Design System, which includes following the [MIT License](LICENSE), using our provided solutions for reporting issues and requesting changes, and sharing their work and findings with the community
+* Beyond their own delivery work, Government organisations may also act in support of the Design System & Steering Committee, as defined above.
 * Supporting Government Organisations will be attributed on the website [location TBD]
 
 ## Contributors (on behalf of Government Organisations)

--- a/ROLES.md
+++ b/ROLES.md
@@ -9,13 +9,13 @@ Matt Sawkill from Code for Australia (@sawks on Slack and GitHub) is the primary
     <figcaption align = "center">The Australian Government Design System “support ecosystem”</figcaption>
 </figure>
 
-## Maintainers (Technical Steering Committee)
+## Maintainers (Steering Committee)
 
-> A Maintainer is as a member of the Technical Steering Committee. The group of Maintainers forms the Steering Committee.
+> A Maintainer is as a member of the Steering Committee. The group of Maintainers forms the Steering Committee.
 
 * Maintainers are the core community members responsible for ongoing management and decision-making for the Design System
 * Anyone can become a Maintainer
-* The group of Maintainers forms the Technical Steering Committee (Steering Committee)
+* The group of Maintainers forms the Steering Committee (Steering Committee)
 * Membership, responsibilities expectations of the Steering Committee is covered by this [Steering Committee Charter](CHARTER.md) and our [Code of Conduct](CODE-OF-CONDUCT.md)
 * In Steering Committee, Maintainers have equal voting rights, and there is no other hierarchy within this group
 * Effectively they are the product managers and core developers of the Design System, leading the RFC process and facilitating working groups in order to make consensus decisions over technical architecture and future direction

--- a/notes/meetings/2021-08/august-24.md
+++ b/notes/meetings/2021-08/august-24.md
@@ -33,20 +33,20 @@ We acknowledged the organisations represented by attendees.
 
 EC explained the goals of the project and the [TSC charter](https://github.com/designsystemau/TSC/blob/main/CHARTER.md#goals-of-the-project).
 
-## Technical Steering Committee and Governance
+## Steering Committee and Governance
 
 MS explained the [roles](https://github.com/designsystemau/TSC/blob/main/ROLES.md) of TSC, Supporting Organisations, Government Agencies and Contributors
 
 DW introduced the [Code of Conduct](https://github.com/designsystemau/TSC/blob/main/CODE-OF-CONDUCT.md), TSC [structure](https://github.com/designsystemau/TSC/) and [RFC process](https://github.com/designsystemau/RFCs/).
 
 DW's notes:
-- We have created the Technical Steering Committee
+- We have created the Steering Committee
 - We have a Charter that outlines how we want to organise the TSC
 - We have outlined how we think changes should be implemented to the Design System via the RFC process
 - All of those things are starting positions and can be iterated on by the community now
 - Everything we do we will do in the open
 - The TSC meeting notes will published including for this meeting [Reference](https://raw.githubusercontent.com/tc39/notes/master/meetings/2021-07/july-13.md)
-- TSC definition: Monitors and reviews project status, as well as provide oversight of the deliverables. The Technical Steering Committee provides a stabilizing influence so organizational concepts and directions are established and maintained with a visionary view.
+- TSC definition: Monitors and reviews project status, as well as provide oversight of the deliverables. The Steering Committee provides a stabilizing influence so organizational concepts and directions are established and maintained with a visionary view.
 
 ## Managing departmental risk
 

--- a/partners/Code-for-Australia.md
+++ b/partners/Code-for-Australia.md
@@ -11,13 +11,13 @@ Code for Australia are responsible for:
 - Helping raise awareness of the Design System and its community supported model with existing and potential users
 - Sharing feedback with the Technical Steering Committee
 - Granting time and resources for their employees to work on Design System maintenance tasks
-- Providing expert advice to the TSC on specific issues
+- Providing expert advice to the Steering Committee on specific issues
 - Providing financial support to help cover costs incurred in managing and supporting the Design System and associated community events
 - Assisting the Technical Steering Committee with media relations and outreach
 - Assisting the Technical Steering Committee with community and event management
 - Assisting the Technical Steering Committee in direct engagement with exisiting and potential Government users of the Design System
 
-## TSC Responsibilities
+## Steering Committee Responsibilities
 The Technical Steering Committee are responsible for:
 - Keeping Code for Australia informed of forthcoming activities and decisions made which are relevant to Code for Australia's work, via communication in this repository and our Slack community
 - Governance of Code for Australia's conduct in support of the Design System

--- a/partners/Code-for-Australia.md
+++ b/partners/Code-for-Australia.md
@@ -3,22 +3,22 @@
 _Agreement date: 3 September 2021_
 
 ## Parties
-This document is an agreement between the Technical Steering Committee, and Code for Aus Pty Ltd (Code for Australia) - represented by [Matt Sawkill, Managing Director](https://github.com/sawks), covering activities performed in support of the community maintained Australian Government Design System.
+This document is an agreement between the Steering Committee, and Code for Aus Pty Ltd (Code for Australia) - represented by [Matt Sawkill, Managing Director](https://github.com/sawks), covering activities performed in support of the community maintained Australian Government Design System.
 
 ## Code for Australia Responsibilities
 Code for Australia are responsible for:
 - Working in the open and communicating with transparency about their role in support of the Design System
 - Helping raise awareness of the Design System and its community supported model with existing and potential users
-- Sharing feedback with the Technical Steering Committee
+- Sharing feedback with the Steering Committee
 - Granting time and resources for their employees to work on Design System maintenance tasks
 - Providing expert advice to the Steering Committee on specific issues
 - Providing financial support to help cover costs incurred in managing and supporting the Design System and associated community events
-- Assisting the Technical Steering Committee with media relations and outreach
-- Assisting the Technical Steering Committee with community and event management
-- Assisting the Technical Steering Committee in direct engagement with exisiting and potential Government users of the Design System
+- Assisting the Steering Committee with media relations and outreach
+- Assisting the Steering Committee with community and event management
+- Assisting the Steering Committee in direct engagement with exisiting and potential Government users of the Design System
 
 ## Steering Committee Responsibilities
-The Technical Steering Committee are responsible for:
+The Steering Committee are responsible for:
 - Keeping Code for Australia informed of forthcoming activities and decisions made which are relevant to Code for Australia's work, via communication in this repository and our Slack community
 - Governance of Code for Australia's conduct in support of the Design System
 - Making the broader community aware of Code for Australia's involvement

--- a/partners/README.md
+++ b/partners/README.md
@@ -5,20 +5,20 @@
 _Agreement date: {DD Month Year}_
 
 ## Parties
-This document is an agreement between the Technical Steering Committee, and {Supporting Organisation} - represented by {Contact name, role & github account}, covering activities performed in support of the community maintained Australian Government Design System.
+This document is an agreement between the Steering Committee, and {Supporting Organisation} - represented by {Contact name, role & github account}, covering activities performed in support of the community maintained Australian Government Design System.
 
 ## {Supporting Organisation} Responsibilities
 {Supporting Organisation} are responsible for:
 - Working in the open and communicating with transparency about their role in support of the Design System
 - Helping raise awareness of the Design System and its community supported model with existing and potential users
-- Sharing feedback with the Technical Steering Committee
+- Sharing feedback with the Steering Committee
 - (delete or add points below as agreed)
 - Granting time and resources for their employees to work on Design System maintenance tasks
 - Providing expert advice to the Steering Committee on specific issues
 - Providing financial support to help cover costs incurred in managing and supporting the Design System and associated community events
 
 ## Steering Committee Responsibilities
-The Technical Steering Committee are responsible for:
+The Steering Committee are responsible for:
 - Keeping {Supporting Organisation} informed of forthcoming activities and decisions made which are relevant to {Supporting Organisation}'s work, via communication in this repository and our Slack community
 - Governance of {Supporting Organisation}'s conduct in support of the Design System
 - Making the broader community aware of {Supporting Organisation}'s involvement

--- a/partners/README.md
+++ b/partners/README.md
@@ -14,10 +14,10 @@ This document is an agreement between the Technical Steering Committee, and {Sup
 - Sharing feedback with the Technical Steering Committee
 - (delete or add points below as agreed)
 - Granting time and resources for their employees to work on Design System maintenance tasks
-- Providing expert advice to the TSC on specific issues
+- Providing expert advice to the Steering Committee on specific issues
 - Providing financial support to help cover costs incurred in managing and supporting the Design System and associated community events
 
-## TSC Responsibilities
+## Steering Committee Responsibilities
 The Technical Steering Committee are responsible for:
 - Keeping {Supporting Organisation} informed of forthcoming activities and decisions made which are relevant to {Supporting Organisation}'s work, via communication in this repository and our Slack community
 - Governance of {Supporting Organisation}'s conduct in support of the Design System


### PR DESCRIPTION
Following this RFC being accepted: https://github.com/designsystemau/RFCs/pull/10, which was to rename TSC to Steering Committee. 

I have gone through this repo and updated: 
* Any reference of "TSC" to "Steering Committee" 
* Any reference of "Technical Steering Committee" to "Steering Committee" (assumes we don't abbreviate as SC)
* Updated this repo references' to its' own URL

